### PR TITLE
Ability to create directly from XML

### DIFF
--- a/Yr/Yr.php
+++ b/Yr/Yr.php
@@ -53,7 +53,7 @@ class Yr
     }
 
     /**
-     * This method builds the Yr object from the freely available Yr api.
+     * This method downloads and builds the Yr object from the freely available Yr api.
      *
      * Notice that you have to be very specific about the location.
      * Use the same location as you will find on the yr.no site. For instance:
@@ -130,21 +130,45 @@ class Yr
         }
 
         // Download the periodic xml if we don't have it
-        self::downloadData(
+        $xml_periodic = self::downloadData(
             "$baseurl/$location/forecast.xml",
             $xml_periodic_path,
             $cache_life
         );
 
         // Download the hourly xml if we don't have it
-        self::downloadData(
+        $xml_hourly = self::downloadData(
             "$baseurl/$location/forecast_hour_by_hour.xml",
             $xml_hourly_path,
             $cache_life
         );
+        
+        return self::createFromXML($xml_periodic, $xml_hourly);
+    }
+    
+    /**
+	 * Build the Yr object
+	 *
+	 * @param String $periodic XML file content
+	 * @param String $hourly XML file content
+	 *
+	 * @return Location
+	 *
+	 * @throws \InvalidArgumentException
+	 * @throws \RuntimeException
+	 */
+	 public static function createFromXML($periodic, $hourly)
+	{
+	    if (!isset($periodic) || empty($periodic)) {
+			throw new \InvalidArgumentException("Periodic XML document need to be set");
+		}
 
-        $xml_hourly = new \SimpleXMLElement($xml_hourly_path, null, true);
-        $xml_periodic = new \SimpleXMLElement($xml_periodic_path, null, true);
+		if (!isset($hourly) || empty($hourly)) {
+			throw new \InvalidArgumentException("Hourly XML document need to be set");
+		}
+
+        $xml_hourly = new \SimpleXMLElement($hourly);
+        $xml_periodic = new \SimpleXMLElement($periodic);
 
         // Forecasts
         $forecasts_hourly   = self::getForecastsFromXml($xml_hourly);
@@ -301,6 +325,7 @@ class Yr
      * @param String  $url
      * @param String  $path
      * @param integer $cacheLife
+     * @return String XML content
      */
     private static function downloadData($url, $path, $cacheLife)
     {
@@ -310,8 +335,10 @@ class Yr
             if (!empty($xml_content)) {
                 // Only cache if there is content from request
                 file_put_contents($path, $xml_content);
+                return $xml_content;
             }
         }
+        return file_get_contents($path);
     }
 
     /**


### PR DESCRIPTION
using the new `createFromXML` you can now create the whole Yr object without having to use the built in download and cache functions.
